### PR TITLE
⚡ Optimize redundant `findIndex` calls in ProjectList render

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,42 @@
+const detailButtons = [
+  { id: 'back', url: null },
+  { id: 'image', url: 'img.jpg' },
+  { id: 'live', url: 'http://live' },
+  { id: 'github', url: 'http://github' }
+];
+
+const ITERATIONS = 10000000;
+
+console.log('Running benchmark...');
+
+const startUnoptimized = performance.now();
+let dummy1 = 0;
+for (let i = 0; i < ITERATIONS; i++) {
+  const live1 = detailButtons.findIndex(b => b.id === 'live');
+  const live2 = detailButtons.findIndex(b => b.id === 'live');
+  const live3 = detailButtons.findIndex(b => b.id === 'live');
+  const github1 = detailButtons.findIndex(b => b.id === 'github');
+  const github2 = detailButtons.findIndex(b => b.id === 'github');
+  const github3 = detailButtons.findIndex(b => b.id === 'github');
+  dummy1 += live1 + github1;
+}
+const endUnoptimized = performance.now();
+
+const startOptimized = performance.now();
+let dummy2 = 0;
+for (let i = 0; i < ITERATIONS; i++) {
+  const live = detailButtons.findIndex(b => b.id === 'live');
+  const github = detailButtons.findIndex(b => b.id === 'github');
+  const live1 = live;
+  const live2 = live;
+  const live3 = live;
+  const github1 = github;
+  const github2 = github;
+  const github3 = github;
+  dummy2 += live1 + github1;
+}
+const endOptimized = performance.now();
+
+console.log(`Unoptimized: ${(endUnoptimized - startUnoptimized).toFixed(2)}ms`);
+console.log(`Optimized: ${(endOptimized - startOptimized).toFixed(2)}ms`);
+console.log(`Improvement: ${(((endUnoptimized - startUnoptimized) - (endOptimized - startOptimized)) / (endUnoptimized - startUnoptimized) * 100).toFixed(2)}%`);

--- a/src/components/pixelplay/ProjectList.tsx
+++ b/src/components/pixelplay/ProjectList.tsx
@@ -240,6 +240,9 @@ export default function ProjectList() {
 
   if (project) {
     const title = project.title;
+    const liveIndex = detailButtons.findIndex(b => b.id === 'live');
+    const githubIndex = detailButtons.findIndex(b => b.id === 'github');
+
     return (
       <div className="w-full h-full flex flex-col p-1 sm:p-2 md:p-3 text-white animate-pixel-in relative">
         <div className="absolute inset-0 z-0 opacity-20">
@@ -325,32 +328,32 @@ export default function ProjectList() {
                 </div>
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 pt-2">
-                  {project.liveUrl && (
+                  {project.liveUrl && liveIndex !== -1 && (
                     <Button
-                      ref={el => { if (el) { detailItemRefs.current[2] = el; } }}
+                      ref={el => { if (el) { detailItemRefs.current[liveIndex] = el; } }}
                       className={cn(
                         "w-full bg-primary hover:bg-primary/90 text-primary-foreground font-headline text-xs py-4 sm:py-5 cursor-pointer transition-all",
-                        selectedDetailButton === detailButtons.findIndex(b => b.id === 'live') ? 'ring-4 ring-white scale-[1.02] z-10' : ''
+                        selectedDetailButton === liveIndex ? 'ring-4 ring-white scale-[1.02] z-10' : ''
                       )}
                       aria-label={`${t('projects.visitWebsite')} ${title}`}
-                      onClick={() => handleDetailButtonClick(detailButtons.findIndex(b => b.id === 'live'))}
-                      onMouseEnter={() => handleDetailButtonHover(detailButtons.findIndex(b => b.id === 'live'))}
+                      onClick={() => handleDetailButtonClick(liveIndex)}
+                      onMouseEnter={() => handleDetailButtonHover(liveIndex)}
                     >
                       <Globe className="mr-2 h-4 w-4" />
                       <span className="text-xs sm:text-sm uppercase tracking-wider">{t('projects.visitWebsite')}</span>
                     </Button>
                   )}
-                  {project.githubUrl && (
+                  {project.githubUrl && githubIndex !== -1 && (
                     <Button
-                      ref={el => { if (el) { detailItemRefs.current[detailButtons.findIndex(b => b.id === 'github')] = el; } }}
+                      ref={el => { if (el) { detailItemRefs.current[githubIndex] = el; } }}
                       variant="outline"
                       className={cn(
                         "w-full font-headline border-accent text-accent hover:bg-accent hover:text-accent-foreground text-xs py-4 sm:py-5 cursor-pointer transition-all",
-                        selectedDetailButton === detailButtons.findIndex(b => b.id === 'github') ? 'ring-4 ring-accent bg-accent/20 scale-[1.02] z-10' : ''
+                        selectedDetailButton === githubIndex ? 'ring-4 ring-accent bg-accent/20 scale-[1.02] z-10' : ''
                       )}
                       aria-label={`View ${title} on GitHub`}
-                      onClick={() => handleDetailButtonClick(detailButtons.findIndex(b => b.id === 'github'))}
-                      onMouseEnter={() => handleDetailButtonHover(detailButtons.findIndex(b => b.id === 'github'))}
+                      onClick={() => handleDetailButtonClick(githubIndex)}
+                      onMouseEnter={() => handleDetailButtonHover(githubIndex)}
                     >
                       <Github className="mr-2 h-4 w-4" />
                       <span className="text-xs sm:text-sm uppercase tracking-wider">GitHub</span>


### PR DESCRIPTION
💡 **What:**
Pre-computed the indices for the 'live' and 'github' buttons once at the start of the render function in `src/components/pixelplay/ProjectList.tsx`, reusing these variables in the JSX where `detailButtons.findIndex` was previously called redundantly. I also added safety checks (`!== -1`) to ensure the elements actually exist.

🎯 **Why:**
Previously, `detailButtons.findIndex` was invoked multiple times for both the 'live' and 'github' buttons for things like element refs, class evaluation, click handlers, and hover handlers. Calculating these values once per render eliminates up to 8 repetitive array traversals per re-render, optimizing performance and resolving hardcoded indices (e.g. `detailItemRefs.current[2]`).

📊 **Measured Improvement:**
A focused benchmark was constructed to simulate the redundant operations across 10,000,000 iterations:
*   **Unoptimized baseline:** 578.46ms
*   **Optimized approach:** 241.37ms
*   **Improvement:** 58.27% reduction in execution time for this code path.

---
*PR created automatically by Jules for task [2075856431680423281](https://jules.google.com/task/2075856431680423281) started by @faaadelmr*