### PR TITLE
🔒 Fix tabnabbing vulnerability in window.open

### DIFF
--- a/src/components/pixelplay/ProjectList.tsx
+++ b/src/components/pixelplay/ProjectList.tsx
@@ -149,7 +149,7 @@ export default function ProjectList() {
         return;
       }
       if (selectedButton.url) {
-        window.open(selectedButton.url, '_blank');
+        window.open(selectedButton.url, '_blank', 'noopener,noreferrer');
       }
     }
   }, [detailButtons, playSelect, handleBackToList]);
@@ -173,7 +173,7 @@ export default function ProjectList() {
     }
 
     if (selectedButton.url) {
-      window.open(selectedButton.url, '_blank');
+      window.open(selectedButton.url, '_blank', 'noopener,noreferrer');
     }
   }, [viewingProjectIndex, selectedDetailButton, playSelect, handleBackToList, detailButtons]);
 


### PR DESCRIPTION
🎯 **What:** Fixed a reverse tabnabbing vulnerability in `src/components/pixelplay/ProjectList.tsx` by modifying `window.open` calls.
⚠️ **Risk:** When using `window.open` with `_blank` without `noopener` and `noreferrer`, the newly opened page has partial access to the original page's `window` object via `window.opener`. A malicious page could use this to redirect the original tab to a phishing site.
🛡️ **Solution:** Added `'noopener,noreferrer'` as the window features argument to both `window.open` calls in `ProjectList.tsx` to prevent the new tab from accessing the `window.opener` object.

---
*PR created automatically by Jules for task [12658626094275120719](https://jules.google.com/task/12658626094275120719) started by @faaadelmr*