### PR TITLE
🔒 [security] Fix tabnabbing vulnerability in ProjectList.tsx

### DIFF
--- a/src/components/pixelplay/ProjectList.tsx
+++ b/src/components/pixelplay/ProjectList.tsx
@@ -149,7 +149,7 @@ export default function ProjectList() {
         return;
       }
       if (selectedButton.url) {
-        window.open(selectedButton.url, '_blank');
+        window.open(selectedButton.url, '_blank', 'noopener,noreferrer');
       }
     }
   }, [detailButtons, playSelect, handleBackToList]);
@@ -173,7 +173,7 @@ export default function ProjectList() {
     }
 
     if (selectedButton.url) {
-      window.open(selectedButton.url, '_blank');
+      window.open(selectedButton.url, '_blank', 'noopener,noreferrer');
     }
   }, [viewingProjectIndex, selectedDetailButton, playSelect, handleBackToList, detailButtons]);
 


### PR DESCRIPTION
### 🔒 Security Fix: Tabnabbing Vulnerability Mitigation

#### 🎯 What:
Fixed a tabnabbing vulnerability in `src/components/pixelplay/ProjectList.tsx` by ensuring all `window.open` calls that use `_blank` also include `noopener,noreferrer`.

#### ⚠️ Risk:
When opening a link with `window.open(url, '_blank')` without security headers, the target page gains access to the originating window's `window.opener` object. A malicious site could use this to redirect the original tab to a fraudulent website (e.g., a phishing page) without the user noticing.

#### 🛡️ Solution:
Modified two instances of `window.open` to include the third argument `'noopener,noreferrer'`. This prevents the new browsing context from accessing the `window.opener` property and also suppresses the `Referer` header for added privacy and security.

- `src/components/pixelplay/ProjectList.tsx:152`
- `src/components/pixelplay/ProjectList.tsx:176`

---
*PR created automatically by Jules for task [4719590139871663273](https://jules.google.com/task/4719590139871663273) started by @faaadelmr*